### PR TITLE
Fix issue 2

### DIFF
--- a/src/MarchingCubes.c
+++ b/src/MarchingCubes.c
@@ -1094,14 +1094,14 @@ int marchingCubes(float * img, size_t dim[3], int lo[3], int hi[3], int original
     return EXIT_FAILURE;
   }
   int npt = mcp->nverts;
-  *vs = malloc(npt*sizeof(vec3d));
+  *vs = (vec3d*) malloc(npt*sizeof(vec3d));
   for (int i = 0; i < npt; i++) {
     (*vs)[i].x = mcp->vertices[i].x + lo[0];
     (*vs)[i].y = mcp->vertices[i].y + lo[1];
     (*vs)[i].z = mcp->vertices[i].z + lo[2];
   }
   int ntri = mcp->ntrigs;
-  *ts = malloc(ntri * sizeof(vec3i));
+  *ts = (vec3i*) malloc(ntri * sizeof(vec3i));
   for (int i=0;i<ntri;i++) {
     (*ts)[i].x = mcp->triangles[i].v3;
     (*ts)[i].y = mcp->triangles[i].v2;

--- a/src/meshify.c
+++ b/src/meshify.c
@@ -362,7 +362,7 @@ int meshify(float * img, size_t dim[3], int originalMC, float isolevel, vec3i **
 	//printf("Bounding box for bright voxels: %d..%d %d..%d %d..%d\n", lo[0], hi[0], lo[1], hi[1], lo[2], hi[2]);
 	for (int i=0;i<3;i++) {
 		lo[i] = MAX(lo[i] - 1, 0);
-		hi[i] = MIN(hi[i] + 2, dim[i]);
+		hi[i] = MIN(hi[i] + 2, dim[i]-1);
 	}
 	double startTimeMC = clockMsec();
 	vec3d *pts = NULL;

--- a/src/nii2mesh.c
+++ b/src/nii2mesh.c
@@ -178,7 +178,7 @@ int nii2 (nifti_1_header hdr, float * img, int originalMC, float isolevel, float
 	vec3d *pts = NULL;
 	vec3i *tris = NULL;
 	int ntri, npt;
-	size_t dim[3] = {hdr.dim[1], hdr.dim[2], hdr.dim[3]};
+	size_t dim[3] = {(size_t)hdr.dim[1], (size_t)hdr.dim[2], (size_t)hdr.dim[3]};
 	if (meshify(img, dim, originalMC, isolevel, &tris, &pts, &ntri, &npt, preSmooth, onlyLargest, fillBubbles, verbose) != EXIT_SUCCESS)
 		return EXIT_FAILURE;
 	apply_sform(tris, pts, ntri, npt, hdr.srow_x, hdr.srow_y, hdr.srow_z);
@@ -295,11 +295,11 @@ int main(int argc,char **argv) {
 	double startTime = clockMsec();
 	float * img=NULL;
 #ifdef HAVE_JSON
-        if(strstr(argv[1], ".jnii") - argv[1] == strlen(argv[1])-5)
-                img = load_jnii(argv[1], &hdr);
-        else
+	if(strstr(argv[1], ".jnii") - argv[1] == strlen(argv[1])-5)
+			img = load_jnii(argv[1], &hdr);
+	else
 #endif
-                img = load_nii(argv[1], &hdr);
+	img = load_nii(argv[1], &hdr);
 	if (verbose)
 		printf("load from disk: %ld ms\n", timediff(startTime, clockMsec()));
 	if (img == NULL)


### PR DESCRIPTION
 - This fixes [issue 2](https://github.com/neurolabusc/nii2mesh/issues/2)
 - For your pull request to the main branch, can you modify the code so it does not elicit warnings with Clang and gcc (I think you just need to explicity typecast the pointers):

Clang
```
meshify.c:713:37: warning: passing 'short [8]' to parameter of type 'unsigned short *' converts between pointers to integer types with different sign [-Wpointer-sign]
                if(jdata_decode((void **)&imgRaw, hdr->dim, hdr->dim+1, 3, &type, jniidata)!=0){
                                                  ^~~~~~~~
meshify.c:568:47: note: passing argument to parameter 'ndim' here
int  jdata_decode(void **vol, unsigned short *ndim, unsigned short *dims, int maxdim, char **type, cJSON *obj){
                                              ^
meshify.c:713:47: warning: passing 'short *' to parameter of type 'unsigned short *' converts between pointers to integer types with different sign [-Wpointer-sign]
                if(jdata_decode((void **)&imgRaw, hdr->dim, hdr->dim+1, 3, &type, jniidata)!=0){
                                                            ^~~~~~~~~~
meshify.c:568:69: note: passing argument to parameter 'dims' here
int  jdata_decode(void **vol, unsigned short *ndim, unsigned short *dims, int maxdim, char **type, cJSON *obj){
                                                                    ^
meshify.c:759:28: warning: passing 'short *' to parameter of type 'unsigned short *' converts between pointers to integer types with different sign [-Wpointer-sign]
                        array3d_row2col(&img32, hdr->dim+1);
                                                ^~~~~~~~~~
meshify.c:621:51: note: passing argument to parameter 'dim' here
void array3d_row2col(float **vol, unsigned short *dim){
                                                  ^
meshify.c:950:24: warning: passing 'unsigned int *' to parameter of type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                        write_ubjsonint(1,&keylen,fp);
                                                          ^~~~~~~
meshify.c:856:36: note: passing argument to parameter 'dat' here
void write_ubjsonint(int len, int *dat, FILE *fp){
                                   ^
meshify.c:982:33: warning: passing 'unsigned int *' to parameter of type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                                                write_ubjsonint(ntri*3, newtris, fp);
                                                                                        ^~~~~~~
meshify.c:856:36: note: passing argument to parameter 'dat' here
void write_ubjsonint(int len, int *dat, FILE *fp){
```

gcc
```
meshify.c: In function 'float* load_jnii(const char*, nifti_1_header*)':
meshify.c:713:56: error: invalid conversion from 'short int*' to 'short unsigned int*' [-fpermissive]
  713 |                 if(jdata_decode((void **)&imgRaw, hdr->dim, hdr->dim+1, 3, &type, jniidata)!=0){
      |                                                   ~~~~~^~~
      |                                                        |
      |                                                        short int*
meshify.c:568:47: note:   initializing argument 2 of 'int jdata_decode(void**, short unsigned int*, short unsigned int*, int, char**, cJSON*)'
  568 | int  jdata_decode(void **vol, unsigned short *ndim, unsigned short *dims, int maxdim, char **type, cJSON *obj){
      |                               ~~~~~~~~~~~~~~~~^~~~
meshify.c:713:69: error: invalid conversion from 'short int*' to 'short unsigned int*' [-fpermissive]
  713 |                 if(jdata_decode((void **)&imgRaw, hdr->dim, hdr->dim+1, 3, &type, jniidata)!=0){
      |                                                             ~~~~~~~~^~
      |                                                                     |
      |                                                                     short int*
meshify.c:568:69: note:   initializing argument 3 of 'int jdata_decode(void**, short unsigned int*, short unsigned int*, int, char**, cJSON*)'
  568 | int  jdata_decode(void **vol, unsigned short *ndim, unsigned short *dims, int maxdim, char **type, cJSON *obj){
      |                                                     ~~~~~~~~~~~~~~~~^~~~
meshify.c:759:57: error: invalid conversion from 'short int*' to 'short unsigned int*' [-fpermissive]
  759 |                         array3d_row2col(&img32, hdr->dim+1);
      |                                                 ~~~~~~~~^~
      |                                                         |
      |                                                         short int*
meshify.c:621:51: note:   initializing argument 2 of 'void array3d_row2col(float**, short unsigned int*)'
  621 | void array3d_row2col(float **vol, unsigned short *dim){
      |                                   ~~~~~~~~~~~~~~~~^~~
meshify.c: In function 'int save_bmsh(const char*, vec3i*, vec3d*, int, int, bool, bool)':
meshify.c:950:59: error: invalid conversion from 'unsigned int*' to 'int*' [-fpermissive]
  950 |                                         write_ubjsonint(1,&keylen,fp);
      |                                                           ^~~~~~~
      |                                                           |
      |                                                           unsigned int*
meshify.c:856:36: note:   initializing argument 2 of 'void write_ubjsonint(int, int*, FILE*)'
  856 | void write_ubjsonint(int len, int *dat, FILE *fp){
      |                               ~~~~~^~~
meshify.c:982:89: error: invalid conversion from 'unsigned int*' to 'int*' [-fpermissive]
  982 |                                                                 write_ubjsonint(ntri*3, newtris, fp);
      |                                                                                         ^~~~~~~
      |                                                                                         |
      |                                                                                         unsigned int
meshify.c:856:36: note:   initializing argument 2 of 'void write_ubjsonint(int, int*, FILE*)'
  856 | void write_ubjsonint(int len, int *dat, FILE *fp){
```